### PR TITLE
Handles early exit

### DIFF
--- a/src/from-client.ts
+++ b/src/from-client.ts
@@ -60,6 +60,9 @@ export class QueryIterableClient<T> extends QueryIterable<T> {
                 let started;
                 return {
                     next(): Promise<IteratorResult<T>> {
+                        if (ctrl.signal.aborted) {
+                            return Promise.resolve({ value: undefined, done: true });
+                        }
                         if (!started) {
                             self.client.query(qs);
                             started = true;
@@ -68,7 +71,11 @@ export class QueryIterableClient<T> extends QueryIterable<T> {
                             r = reject;
                             i.next().then(resolve, reject);
                         });
-                    }
+                    },
+                    return() {
+                        ctrl.abort();
+                        return Promise.resolve({ value: undefined, done: true });
+                    },
                 };
             }
         };

--- a/src/from-pool.ts
+++ b/src/from-pool.ts
@@ -56,6 +56,9 @@ export class QueryIterablePool<T> extends QueryIterable<T> {
             [Symbol.asyncIterator](): AsyncIterator<T> {
                 return {
                     next(): Promise<IteratorResult<T>> {
+                        if (ctrl.signal.aborted) {
+                            return Promise.resolve({ value: undefined, done: true });
+                        }
                         if (self.client) {
                             return new Promise((resolve, reject) => {
                                 r = reject;
@@ -74,7 +77,11 @@ export class QueryIterablePool<T> extends QueryIterable<T> {
                             c.query(qs);
                             return this.next();
                         });
-                    }
+                    },
+                    return() {
+                        ctrl.abort();
+                        return Promise.resolve({ value: undefined, done: true });
+                    },
                 };
             }
         };


### PR DESCRIPTION
Breaking out of a loop currently hangs. How to reproduce:

```javascript
import pg from 'pg';
import { QueryIterablePool } from 'pg-iterator';

const sql = `
  SELECT 1 AS number
  UNION ALL
  SELECT 2;
`;

const pool = new pg.Pool(...);

try {
  const q = new QueryIterablePool(pool);

  for await (const row of q.query(sql)) {
    console.log(row);
    break;
  }
} finally {
  await pool.end();
}
```

This PR addresses the issue.